### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/viomi_vacuum_v8/manifest.json
+++ b/custom_components/viomi_vacuum_v8/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "viomi_vacuum_v8",
   "name": "Viomi Vacuum V8",
+  "version": "1.0.0",
   "documentation": "https://github.com/tykarol/home-assistant-viomi-vacuum-v8",
   "requirements": [
     "construct==2.10.59",


### PR DESCRIPTION
added version in manifest due to log entry: WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'viomi_vacuum_v8'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'viomi_vacuum_v8'

More info: https://developers.home-assistant.io/docs/creating_integration_manifest/#version
https://community.home-assistant.io/t/no-version-key-in-the-manifest-file-for-custom-integration-ha-2021-3-0/286487

Maybe the version does not need to have major.minor.PATCH (so 1.0) only, but every example here: https://github.com/ludeeus/awesomeversion contained 3 numbers.