### PR TITLE
fix: Fixed typo 'battary life' -> 'battery life'

### DIFF
--- a/custom_components/viomi_vacuum_v8/manifest.json
+++ b/custom_components/viomi_vacuum_v8/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "viomi_vacuum_v8",
   "name": "Viomi Vacuum V8",
-  "version": "1.3.1",
+  "version": "2.3.1",
   "documentation": "https://github.com/tykarol/home-assistant-viomi-vacuum-v8",
   "requirements": [
     "construct>=2.10.59",

--- a/custom_components/viomi_vacuum_v8/vacuum.py
+++ b/custom_components/viomi_vacuum_v8/vacuum.py
@@ -168,7 +168,7 @@ ALL_PROPS = [
     "run_state",
     "mode",
     "err_state",
-    "battary_life",
+    "battery_life",
     "box_type",
     "mop_type",
     "s_time",
@@ -279,7 +279,7 @@ class ViomiVacuumEntity(StateVacuumEntity):
     def battery_level(self):
         """Return the battery level of the device."""
         if self.vacuum_state is not None:
-            return self.vacuum_state['battary_life']
+            return self.vacuum_state['battery_life']
 
     @property
     def fan_speed(self):


### PR DESCRIPTION
Fixed typo (`battary_life` -> `battery_life`) and bumped major version, because this may be a breaking change.